### PR TITLE
move / シナリオのインデックスを示す変数を TextWriter 内に移動

### DIFF
--- a/src/classes/gameScenes/ScenarioScene.as
+++ b/src/classes/gameScenes/ScenarioScene.as
@@ -15,7 +15,6 @@ package classes.gameScenes {
         private var sceneParts:Vector.<IScenarioSceneParts> = new Vector.<IScenarioSceneParts>();
         private var animators:Vector.<Animator> = new Vector.<Animator>();
         private var resource:Resource;
-        private var scenarioCounter:int;
         private var textWriter:TextWriter;
 
         public function ScenarioScene() {
@@ -57,16 +56,12 @@ package classes.gameScenes {
 
         private function keyboardEventHandler(event:KeyboardEvent):void {
             if (event.keyCode == Keyboard.ENTER) {
-                if (!textWriter.Writing) {
-                    scenarioCounter++;
-                }
-
-                if (scenarioCounter >= resource.scenarios.length) {
+                if (textWriter.ScenarioCounter >= resource.scenarios.length) {
                     return;
                 }
 
                 for each (var parts:IScenarioSceneParts in sceneParts) {
-                    parts.setScenario(resource.scenarios[scenarioCounter])
+                    parts.setScenario(resource.scenarios[textWriter.ScenarioCounter])
                 }
 
                 for each (parts in sceneParts) {

--- a/src/classes/sceneParts/TextWriter.as
+++ b/src/classes/sceneParts/TextWriter.as
@@ -14,12 +14,14 @@ package classes.sceneParts {
         private var charaCounter:int;
         private var saveText:Boolean;
         private var enterFrameEventDispatcher:Sprite = new Sprite();
+        private var scenarioCounter:int;
 
         public function TextWriter() {
         }
 
         public function execute():void {
             if (enterFrameEventDispatcher.hasEventListener(Event.ENTER_FRAME)) {
+                scenarioCounter++;
                 textWindow.text = currentText;
                 enterFrameEventDispatcher.removeEventListener(Event.ENTER_FRAME, write);
             } else {
@@ -44,6 +46,7 @@ package classes.sceneParts {
         private function write(event:Event):void {
             if (currentText.length <= charaCounter) {
                 charaCounter = 0;
+                scenarioCounter++;
                 enterFrameEventDispatcher.removeEventListener(Event.ENTER_FRAME, write);
                 return;
             }
@@ -56,8 +59,8 @@ package classes.sceneParts {
             // Resource 使用の必要性が無いため実装無し。
         }
 
-        public function get Writing():Boolean {
-            return enterFrameEventDispatcher.hasEventListener(Event.ENTER_FRAME);
+        public function get ScenarioCounter():int {
+            return scenarioCounter;
         }
 
         public function dispatchEvent(e:Event):void {


### PR DESCRIPTION
テキストの表示終了時にカウンターを増やす必要があり、
実現するためには、上記方法か、TextWriter にイベントリスナーを追加するかになる。
イベントよりは、フィールド、プロパティを追加するだけの上記のほうがわかりやすいように思うのでこの方法を採用する。

close #4
