### PR TITLE
fix / テキストウィンドウが間違った位置に配置されていたのを修正

### DIFF
--- a/src/classes/uis/UIContainer.as
+++ b/src/classes/uis/UIContainer.as
@@ -55,9 +55,9 @@ package classes.uis {
         public function AlignUI(baseObjectRect:Rectangle):void {
             baseRect = baseObjectRect;
 
-            textWindow.width = 500;
+            textWindow.width = baseRect.width * 0.7;
             textWindow.height = 150;
-            textWindow.x = (baseRect.width / 2) - (textWindow.width / 2) * -1;
+            textWindow.x = (baseRect.width / 2) - (textWindow.width / 2);
             textWindow.y = baseRect.height * 0.75;
 
             textWindowImage.x = (baseRect.width / 2) - (textWindowImage.width / 2);


### PR DESCRIPTION
修正箇所の計算式の *-1 は消し忘れだと思われる。
明らかに不要な記述だったので削除。

close #12
