### PR TITLE
20210711#22 extend VoicePlayer

### DIFF
--- a/src/classes/contentsLoaders/xmlElements/VoiceElementConverter.as
+++ b/src/classes/contentsLoaders/xmlElements/VoiceElementConverter.as
@@ -8,6 +8,7 @@ package classes.contentsLoaders.xmlElements {
 
         private static const NUMBER_ATTRIBUTE:String = "@number";
         private static const FILE_NAME_ATTRIBUTE:String = "@fileName";
+        private static const CHANNEL_ATTRIBUTE:String = "@channel"
 
         private var voiceDirectory:File;
         private var voiceFileList:Array;
@@ -33,7 +34,6 @@ package classes.contentsLoaders.xmlElements {
                 var voiceFilePath:String = voiceDirectory.nativePath + "/" + (voiceTag[FILE_NAME_ATTRIBUTE]);
                 soundFile = new SoundFile(new File(voiceFilePath));
                 scenario.Voice = soundFile;
-                return;
             }
 
             if (voiceTag.hasOwnProperty(NUMBER_ATTRIBUTE)) {
@@ -53,10 +53,11 @@ package classes.contentsLoaders.xmlElements {
                 soundFile = new SoundFile(voiceFileList[index]);
                 soundFile.Index = voiceTag[NUMBER_ATTRIBUTE];
                 scenario.Voice = soundFile;
-                return;
             }
 
-            throw new ArgumentError("voice 要素には number か fileName 属性が必須です");
+            if (voiceTag.hasOwnProperty(CHANNEL_ATTRIBUTE)) {
+                soundFile.CharacterChannel = parseInt(voiceTag[CHANNEL_ATTRIBUTE])
+            }
         }
     }
 }

--- a/src/classes/sceneContents/SoundFile.as
+++ b/src/classes/sceneContents/SoundFile.as
@@ -11,6 +11,7 @@ package classes.sceneContents {
         private var sound:ISound;
         private var index:int = -1;
         private var volume:Number = 1.0;
+        private var characterChannel:int;
         private var volumeIsDefault:Boolean = true;
 
         public function SoundFile(file:File = null, sound:ISound = null) {
@@ -49,6 +50,14 @@ package classes.sceneContents {
             }
 
             return sound;
+        }
+
+        public function get CharacterChannel():int {
+            return characterChannel;
+        }
+
+        public function set CharacterChannel(value:int):void {
+            characterChannel = value;
         }
 
         /**

--- a/src/classes/sceneParts/VoicePlayer.as
+++ b/src/classes/sceneParts/VoicePlayer.as
@@ -44,7 +44,11 @@ package classes.sceneParts {
         }
 
         public function setScenario(scenario:Scenario):void {
-            voiceFile = scenario.Voice;
+            if (scenario.Voice && scenario.Voice.CharacterChannel == characterChannel) {
+                voiceFile = scenario.Voice;
+            } else {
+                voiceFile = null;
+            }
 
             for each (var order:StopOrder in scenario.StopOrders) {
                 if (order.Target == "voice" && order.Index == characterChannel) {

--- a/src/tests/contentsLoaders/xmlElements/TestVoiceElement.as
+++ b/src/tests/contentsLoaders/xmlElements/TestVoiceElement.as
@@ -13,7 +13,7 @@ package tests.contentsLoaders.xmlElements {
 
         private function testConvert():void {
             var xmlList:XMLList = new XMLList("<scenario>" + "<voice fileName=\"testFile\" />" + "</scenario>");
-            var xmlList2:XMLList = new XMLList("<scenario>" + "<voice number=\"001\" />" + "</scenario>");
+            var xmlList2:XMLList = new XMLList("<scenario>" + "<voice number=\"001\" channel=\"2\" />" + "</scenario>");
             var xml:XML = xmlList.voice[0];
 
             var f:File = new File(File.applicationDirectory.nativePath);
@@ -26,6 +26,7 @@ package tests.contentsLoaders.xmlElements {
             var fromIndex:Scenario = new Scenario();
             vc.convert(xmlList2[0], fromIndex);
             Assert.areEqual(fromIndex.Voice.FileName, "002.mp3");
+            Assert.areEqual(fromIndex.Voice.CharacterChannel, 2);
         }
     }
 }


### PR DESCRIPTION
- add / Voice要素から、再生するチャンネルを設定できるよう実装
- test / VoiceElementConverter に channel 属性のテストを追加
- add / VoicePlayer をチャンネル別で再生するよう実装

close #22
