### PR TITLE
20210712#28 feat option

### DIFF
--- a/src/classes/gameScenes/ScenarioScene.as
+++ b/src/classes/gameScenes/ScenarioScene.as
@@ -9,6 +9,7 @@ package classes.gameScenes {
     import classes.sceneContents.Scenario;
     import classes.sceneParts.*;
     import classes.uis.UIContainer;
+    import classes.uis.OptionUI;
 
     public class ScenarioScene extends Sprite {
 
@@ -19,6 +20,7 @@ package classes.gameScenes {
         private var textWriter:TextWriter;
         private var bgmPlayer:BGMPlayer;
         private var lastExecuteScenario:Scenario;
+        private var optionUI:OptionUI;
 
         public function ScenarioScene() {
             addChild(ui);
@@ -77,6 +79,7 @@ package classes.gameScenes {
                 }
 
                 bgmPlayer.execute();
+                optionUI = new OptionUI(resource);
             }
         }
 
@@ -104,6 +107,12 @@ package classes.gameScenes {
                 }
 
                 lastExecuteScenario = scenario;
+            }
+
+            if (event.keyCode == Keyboard.O) {
+                optionUI.show();
+                stage.focus = optionUI;
+                addChild(optionUI);
             }
 
             if (event.keyCode == Keyboard.Q) {

--- a/src/classes/uis/OptionUI.as
+++ b/src/classes/uis/OptionUI.as
@@ -1,0 +1,13 @@
+package classes.uis {
+
+    import flash.display.Sprite;
+
+    public class OptionUI extends Sprite {
+
+        public function OptionUI() {
+        }
+
+        public function show():void {
+        }
+    }
+}

--- a/src/classes/uis/OptionUI.as
+++ b/src/classes/uis/OptionUI.as
@@ -6,6 +6,7 @@ package classes.uis {
     import flash.text.TextField;
     import flash.events.KeyboardEvent;
     import flash.ui.Keyboard;
+    import flash.text.TextFormat;
 
     public class OptionUI extends Sprite {
 
@@ -14,11 +15,17 @@ package classes.uis {
 
         public function OptionUI(r:Resource) {
             res = r;
+            addChild(textField);
+            textField.alpha = 0;
+            textField.width = 800;
+            textField.height = 300;
+            textField.defaultTextFormat = new TextFormat("Courier", 26, 0xffffff);
         }
 
         public function show():void {
             textField.alpha = 0;
             textField.visible = true;
+            updateStatus();
             addEventListener(Event.ENTER_FRAME, fadeIn);
         }
 
@@ -26,10 +33,20 @@ package classes.uis {
             addEventListener(Event.ENTER_FRAME, fadeOut);
         }
 
+        private function updateStatus():void {
+            textField.text = "";
+            textField.text += "voice 	<V " + res.voiceVolume + " v>" + "\n";
+            textField.text += "BGVoice	<B " + res.backVoiceVolume + " b>" + "\n";
+            textField.text += "BGMV 	<M " + res.bgmVolume + " m>" + "\n";
+            textField.text += "se		<S " + res.seVolume + " s>" + "\n";
+        }
+
         private function fadeIn(e:Event):void {
+            trace(textField.alpha);
             textField.alpha += 0.2;
             if (textField.alpha > 1.0) {
                 removeEventListener(Event.ENTER_FRAME, fadeIn);
+                addEventListener(KeyboardEvent.KEY_DOWN, keyboardEventHandler);
             }
         }
 
@@ -52,6 +69,8 @@ package classes.uis {
                 } else {
                     res.voiceVolume += 0.05;
                 }
+
+                updateStatus();
             }
 
             if (e.keyCode == Keyboard.B) {
@@ -60,6 +79,8 @@ package classes.uis {
                 } else {
                     res.backVoiceVolume += 0.05;
                 }
+
+                updateStatus();
             }
 
             if (e.keyCode == Keyboard.S) {
@@ -68,6 +89,8 @@ package classes.uis {
                 } else {
                     res.seVolume += 0.05;
                 }
+
+                updateStatus();
             }
 
             if (e.keyCode == Keyboard.M) {
@@ -76,6 +99,8 @@ package classes.uis {
                 } else {
                     res.bgmVolume += 0.05;
                 }
+
+                updateStatus();
             }
         }
     }

--- a/src/classes/uis/OptionUI.as
+++ b/src/classes/uis/OptionUI.as
@@ -34,15 +34,28 @@ package classes.uis {
         }
 
         private function updateStatus():void {
+            function zeroPadding(str:String):String {
+                while (str.length < 3) {
+                    str = "0" + str;
+                }
+
+                return str;
+            }
+
+            var vv:String = zeroPadding(Math.round(res.voiceVolume * 100).toString());
+            var bv:String = zeroPadding(Math.round(res.backVoiceVolume * 100).toString());
+            var mv:String = zeroPadding(Math.round(res.bgmVolume * 100).toString());
+            var sv:String = zeroPadding(Math.round(res.seVolume * 100).toString());
+
             textField.text = "";
-            textField.text += "voice 	<V " + res.voiceVolume + " v>" + "\n";
-            textField.text += "BGVoice	<B " + res.backVoiceVolume + " b>" + "\n";
-            textField.text += "BGMV 	<M " + res.bgmVolume + " m>" + "\n";
-            textField.text += "se		<S " + res.seVolume + " s>" + "\n";
+            textField.text += "voice 	<V   " + vv + "    v>" + "\n";
+            textField.text += "BGVoice	<B   " + bv + "    b>" + "\n";
+            textField.text += "BGMV 	<M   " + mv + "    m>" + "\n";
+            textField.text += "se		<S   " + sv + "    s>" + "\n";
+            textField.text += "end 'e' key";
         }
 
         private function fadeIn(e:Event):void {
-            trace(textField.alpha);
             textField.alpha += 0.2;
             if (textField.alpha > 1.0) {
                 removeEventListener(Event.ENTER_FRAME, fadeIn);

--- a/src/classes/uis/OptionUI.as
+++ b/src/classes/uis/OptionUI.as
@@ -66,6 +66,7 @@ package classes.uis {
         private function fadeOut(e:Event):void {
             textField.alpha -= 0.2;
             if (textField.alpha <= 0) {
+                textField.visible = false;
                 removeEventListener(Event.ENTER_FRAME, fadeOut);
             }
         }

--- a/src/classes/uis/OptionUI.as
+++ b/src/classes/uis/OptionUI.as
@@ -1,13 +1,41 @@
 package classes.uis {
 
+    import classes.sceneContents.Resource;
     import flash.display.Sprite;
+    import flash.events.Event;
+    import flash.text.TextField;
 
     public class OptionUI extends Sprite {
 
-        public function OptionUI() {
+        private var textField:TextField = new TextField();
+        private var res:Resource;
+
+        public function OptionUI(r:Resource) {
+            res = r;
         }
 
         public function show():void {
+            textField.alpha = 0;
+            textField.visible = true;
+            addEventListener(Event.ENTER_FRAME, fadeIn);
+        }
+
+        public function hide():void {
+            addEventListener(Event.ENTER_FRAME, fadeOut);
+        }
+
+        private function fadeIn(e:Event):void {
+            textField.alpha += 0.2;
+            if (textField.alpha > 1.0) {
+                removeEventListener(Event.ENTER_FRAME, fadeIn);
+            }
+        }
+
+        private function fadeOut(e:Event):void {
+            textField.alpha -= 0.2;
+            if (textField.alpha <= 0) {
+                removeEventListener(Event.ENTER_FRAME, fadeOut);
+            }
         }
     }
 }

--- a/src/classes/uis/OptionUI.as
+++ b/src/classes/uis/OptionUI.as
@@ -1,20 +1,27 @@
 package classes.uis {
 
     import classes.sceneContents.Resource;
+    import flash.display.Bitmap;
+    import flash.display.BitmapData;
     import flash.display.Sprite;
     import flash.events.Event;
-    import flash.text.TextField;
     import flash.events.KeyboardEvent;
-    import flash.ui.Keyboard;
+    import flash.text.TextField;
     import flash.text.TextFormat;
+    import flash.ui.Keyboard;
 
     public class OptionUI extends Sprite {
 
         private var textField:TextField = new TextField();
+        private var bg:Bitmap;
         private var res:Resource;
 
         public function OptionUI(r:Resource) {
             res = r;
+            bg = new Bitmap(new BitmapData(res.ScreenSize.width, res.ScreenSize.height, false, 0x0));
+            addChild(bg);
+            bg.alpha = 0;
+
             addChild(textField);
             textField.alpha = 0;
             textField.width = 800;
@@ -25,6 +32,8 @@ package classes.uis {
         public function show():void {
             textField.alpha = 0;
             textField.visible = true;
+            bg.alpha = 0;
+            bg.visible = true;
             updateStatus();
             addEventListener(Event.ENTER_FRAME, fadeIn);
         }
@@ -57,7 +66,9 @@ package classes.uis {
 
         private function fadeIn(e:Event):void {
             textField.alpha += 0.2;
+            bg.alpha += 0.15;
             if (textField.alpha > 1.0) {
+                bg.alpha = 0.75;
                 removeEventListener(Event.ENTER_FRAME, fadeIn);
                 addEventListener(KeyboardEvent.KEY_DOWN, keyboardEventHandler);
             }
@@ -65,8 +76,11 @@ package classes.uis {
 
         private function fadeOut(e:Event):void {
             textField.alpha -= 0.2;
+            bg.alpha -= 0.15;
             if (textField.alpha <= 0) {
                 textField.visible = false;
+                bg.alpha = 0;
+                bg.visible = false;
                 removeEventListener(Event.ENTER_FRAME, fadeOut);
             }
         }

--- a/src/classes/uis/OptionUI.as
+++ b/src/classes/uis/OptionUI.as
@@ -4,6 +4,8 @@ package classes.uis {
     import flash.display.Sprite;
     import flash.events.Event;
     import flash.text.TextField;
+    import flash.events.KeyboardEvent;
+    import flash.ui.Keyboard;
 
     public class OptionUI extends Sprite {
 
@@ -35,6 +37,45 @@ package classes.uis {
             textField.alpha -= 0.2;
             if (textField.alpha <= 0) {
                 removeEventListener(Event.ENTER_FRAME, fadeOut);
+            }
+        }
+
+        private function keyboardEventHandler(e:KeyboardEvent):void {
+            if (e.keyCode == Keyboard.E) {
+                removeEventListener(KeyboardEvent.KEY_DOWN, keyboardEventHandler);
+                hide();
+            }
+
+            if (e.keyCode == Keyboard.V) {
+                if (e.shiftKey) {
+                    res.voiceVolume -= 0.05;
+                } else {
+                    res.voiceVolume += 0.05;
+                }
+            }
+
+            if (e.keyCode == Keyboard.B) {
+                if (e.shiftKey) {
+                    res.backVoiceVolume -= 0.05;
+                } else {
+                    res.backVoiceVolume += 0.05;
+                }
+            }
+
+            if (e.keyCode == Keyboard.S) {
+                if (e.shiftKey) {
+                    res.seVolume -= 0.05;
+                } else {
+                    res.seVolume += 0.05;
+                }
+            }
+
+            if (e.keyCode == Keyboard.M) {
+                if (e.shiftKey) {
+                    res.bgmVolume -= 0.05;
+                } else {
+                    res.bgmVolume += 0.05;
+                }
             }
         }
     }


### PR DESCRIPTION
- add / オプション画面のUIとなるクラスを追加
- add / OptionUI に、テキストフィールドのフェードイン、アウト機能を実装
- add / OptionUI に キーボードイベントによる操作機能を実装
- add / ScenarioScene から OptionUI を使用できるよう実装
- fix / オプションの数値表示のフォーマットを変更
- fix / オプション画面終了時、textField.visible を false に変更
- add / オプション画面に半透明の黒背景を追加

close #28
