### PR TITLE
画像描画時の単色背景描画機能

### DIFF
--- a/src/classes/contentsLoaders/xmlElements/ImageElementConverter.as
+++ b/src/classes/contentsLoaders/xmlElements/ImageElementConverter.as
@@ -18,6 +18,7 @@ package classes.contentsLoaders.xmlElements {
         public static const Y_ATTRIBUTE:String = "@y";
         public static const SCALE_ATTRIBUTE:String = "@scale";
         public static const ROTATION_ATTRIBUTE:String = "@rotation";
+        public static const BACKGROUND_COLOR_ATTRIBUTE:String = "@backgroundColor";
 
         public static const STATUS_INHERIT_ATTRIBUTE:String = "@statusInherit";
 
@@ -76,6 +77,12 @@ package classes.contentsLoaders.xmlElements {
                 if (imageTag.hasOwnProperty(ROTATION_ATTRIBUTE)) {
                     if (!isNaN(parseInt(imageTag[ROTATION_ATTRIBUTE]))) {
                         order.rotation = parseInt(imageTag[ROTATION_ATTRIBUTE]);
+                    }
+                }
+
+                if (imageTag.hasOwnProperty(BACKGROUND_COLOR_ATTRIBUTE)) {
+                    if (!isNaN(parseInt(imageTag[BACKGROUND_COLOR_ATTRIBUTE]))) {
+                        order.backgroundColor = parseInt(imageTag[BACKGROUND_COLOR_ATTRIBUTE]);
                     }
                 }
 

--- a/src/classes/sceneContents/ImageOrder.as
+++ b/src/classes/sceneContents/ImageOrder.as
@@ -14,6 +14,7 @@ package classes.sceneContents {
         public var scale:Number = 1.0;
         public var rotation:int = 0;
 
+        public var backgroundColor:uint = 0x00000000;
         public var drawingDepth:Number = 1.0;
         public var statusInherit:Boolean;
 

--- a/src/classes/sceneParts/ImageDrawer.as
+++ b/src/classes/sceneParts/ImageDrawer.as
@@ -44,7 +44,7 @@ package classes.sceneParts {
             }
 
             if (needBitmapAddition) {
-                var bitmap:Bitmap = new Bitmap(new BitmapData(resource.ScreenSize.width, resource.ScreenSize.height, true, 0x0));
+                var bitmap:Bitmap = new Bitmap(new BitmapData(resource.ScreenSize.width, resource.ScreenSize.height, true, currentOrder.backgroundColor));
                 for each (var index:int in currentOrder.indexes) {
                     if (index > 0) {
                         bitmap.bitmapData.draw(resource.BitmapDatas[index]);

--- a/src/tests/contentsLoaders/xmlElements/TestImageElementConverter.as
+++ b/src/tests/contentsLoaders/xmlElements/TestImageElementConverter.as
@@ -19,7 +19,7 @@ package tests.contentsLoaders.xmlElements {
 
             imageElementConverter.FileList = fileList;
 
-            var testXML1:XML = new XML("<scenario>  <image a=\"Aimg01\" c=\"Cimg01\" x=\"-100\" scale=\"2.0\" rotation=\"20\" statusInherit=\"true\" target=\"front\"/> <image a=\"Aimg02\" target=\"main\" /> </scenario>");
+            var testXML1:XML = new XML("<scenario>  <image a=\"Aimg01\" c=\"Cimg01\" x=\"-100\" scale=\"2.0\" rotation=\"20\" backgroundColor=\"0xa\" statusInherit=\"true\" target=\"front\"/> <image a=\"Aimg02\" target=\"main\" /> </scenario>");
             var scenario1:Scenario = new Scenario();
 
             imageElementConverter.convert(testXML1, scenario1);
@@ -31,6 +31,7 @@ package tests.contentsLoaders.xmlElements {
             Assert.areEqual(scenario1.ImagerOrders[0].y, 0);
             Assert.areEqual(scenario1.ImagerOrders[0].scale, 2.0);
             Assert.areEqual(scenario1.ImagerOrders[0].rotation, 20);
+            Assert.areEqual(scenario1.ImagerOrders[0].backgroundColor, 10);
             Assert.isTrue(scenario1.ImagerOrders[0].statusInherit);
             Assert.areEqual(scenario1.ImagerOrders[0].targetLayerIndex, 3);
 


### PR DESCRIPTION
- bug fix / 画像描画時(BitmapData生成時)の挙動を修正
- add / ImageOrder に描画するビットマップデータの背景色を追加
- add / xmlファイルから画像描画時の背景色を指定可能なよう実装
