### PR TITLE
fix / Animator.execute() にアニメーションの追加処理を移行

### DIFF
--- a/src/classes/sceneParts/Animator.as
+++ b/src/classes/sceneParts/Animator.as
@@ -13,6 +13,7 @@ package classes.sceneParts {
         private var animations:Vector.<IAnimation> = new Vector.<IAnimation>();
         private var bitmapContainer:BitmapContainer;
         private var stopAnimationNames:Vector.<String> = new Vector.<String>();
+        private var currentScenario:Scenario;
 
         public function Animator(targetBitmapContainer:BitmapContainer) {
             bitmapContainer = targetBitmapContainer;
@@ -62,7 +63,13 @@ package classes.sceneParts {
         }
 
         public function execute():void {
-            // 実装なし
+            for each (var anime:IAnimation in currentScenario.Animations) {
+                if (anime.TargetLayerIndex == bitmapContainer.LayerIndex) {
+                    addAnimation(anime);
+                }
+            }
+
+            currentScenario = null;
         }
 
         public function setScenario(scenario:Scenario):void {
@@ -80,11 +87,7 @@ package classes.sceneParts {
                 }
             }
 
-            for each (var anime:IAnimation in scenario.Animations) {
-                if (anime.TargetLayerIndex == bitmapContainer.LayerIndex) {
-                    addAnimation(anime);
-                }
-            }
+            currentScenario = scenario;
         }
 
         public function setUI(ui:UIContainer):void {

--- a/src/tests/sceneParts/TestAnimator.as
+++ b/src/tests/sceneParts/TestAnimator.as
@@ -26,6 +26,7 @@ package tests.sceneParts {
             var scenario1:Scenario = new Scenario();
             scenario1.Animations.push(new Shake());
             animator.setScenario(scenario1);
+            animator.execute();
 
             animator.executeAnimations();
             Assert.areEqual(animator.AnimationCount, 1);
@@ -36,6 +37,7 @@ package tests.sceneParts {
             scenario2.Animations.push(shake);
 
             animator.setScenario(scenario2);
+            animator.execute();
 
             // 同種のアニメーションを入れた場合は上書きされるので数は増えない。
             Assert.areEqual(animator.AnimationCount, 1);
@@ -78,6 +80,7 @@ package tests.sceneParts {
             var scenario1:Scenario = new Scenario();
             scenario1.Animations.push(new Shake());
             animator.setScenario(scenario1);
+            animator.execute();
 
             animator.executeAnimations();
             animator.executeAnimations();
@@ -93,6 +96,7 @@ package tests.sceneParts {
             scenario2.StopOrders.push(stopOrder);
 
             animator.setScenario(scenario2);
+            animator.execute();
             animator.executeAnimations();
 
             // Shake の停止命令を setScenario によってセット。


### PR DESCRIPTION
ImageDrawer.execute() よりも前の段階(Animator.setScenario())によって、
アニメーションをセットしていたのが問題だったため、アニメーションをセットするタイミングを一段遅くし、
Animator.exeucte() に変更。

これにより、ImageDrawer.execute() よりも後にアニメーションがセットされるようになるため解決する。

close #33
