### PR TITLE
add / XMLReference の該当項目に使い方の説明を追加

### DIFF
--- a/doc/XMLReference.md
+++ b/doc/XMLReference.md
@@ -41,6 +41,8 @@
 	a-c までの属性内にはファイル名を入力する
 	ImageElementConverter:"@a"
 	ImageElementConverter:"@backgroundColor"
+		8 桁の 16 進数(ARGB)で指定する。 ex : <image backgroundColor="0xffffffff" />
+
 	ImageElementConverter:"@b"
 	ImageElementConverter:"@c"
 	ImageElementConverter:"@rotation"


### PR DESCRIPTION
実装と使い方の認識がずれていたため、背景色描画が動いていないと思っていたが違った。
背景色を 6 桁(RGB) ではなく 8 桁(ARGB) で指定すれば正しく動く。
動作は想定通りのため、コードは修正せず、XML ドキュメントに使用方法の注意を記して対応する issue をクローズする

close #43
