### PR TITLE
20210728#49 最後に選択したシナリオの記録機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/*
 .vscode/settings.json
 scenarios/sampleScenario*
+commonResource/texts/*

--- a/src/Tester.as
+++ b/src/Tester.as
@@ -15,6 +15,7 @@ package {
     import tests.contentsLoaders.xmlElements.TestStopElementConverter;
     import tests.contentsLoaders.TestThumbnailLoader;
     import tests.gameScenes.TestSelectionScene;
+    import tests.contentsLoaders.TestConfiguration;
 
     public class Tester extends Sprite {
         public function Tester() {
@@ -56,6 +57,7 @@ package {
             new TestChapterManager();
             new TestBound();
             new TestMaskSlide();
+            new TestConfiguration();
 
             trace("[Tester]" + " " + Assert.TestCounter + " 回のテストを完了しました");
             NativeApplication.nativeApplication.exit();

--- a/src/classes/contentsLoaders/Configuration.as
+++ b/src/classes/contentsLoaders/Configuration.as
@@ -1,6 +1,12 @@
 package classes.contentsLoaders {
 
     import flash.events.EventDispatcher;
+    import flash.filesystem.File;
+    import flash.filesystem.FileStream;
+    import flash.filesystem.FileMode;
+    import flash.net.URLRequest;
+    import flash.net.URLLoader;
+    import flash.events.Event;
 
     public class Configuration {
 
@@ -38,6 +44,31 @@ package classes.contentsLoaders {
                     fullScreenMode = true;
                 }
             }
+
+            completeEventDispatcher.dispatchEvent(new Event(Event.COMPLETE));
+        }
+
+        public function load(xmlFilePath:String):void {
+            var xmlFile:File = new File(xmlFilePath);
+            if (!xmlFile.exists) {
+                var stream:FileStream = new FileStream();
+                stream.open(xmlFile, FileMode.WRITE);
+                var defaultXMLString:String = "<root><" + ElementName + " ";
+                defaultXMLString += SELECTION_INDEX_ATTRIBUTE.substr(1) + "=\"0\" ";
+                defaultXMLString += FULL_SCREEN_MODE_ATTRIBUTE.substr(1) + "=\"false\"";
+                defaultXMLString += "/></root>"
+
+                stream.writeUTFBytes(defaultXMLString);
+                stream.close();
+            }
+
+            var urlLoader:URLLoader = new URLLoader();
+            urlLoader.addEventListener(Event.COMPLETE, function(e:Event):void {
+                xml = new XML(URLLoader(e.target).data);
+                convert();
+            });
+
+            urlLoader.load(new URLRequest(xmlFile.nativePath));
         }
 
         public function get ElementName():String {

--- a/src/classes/contentsLoaders/Configuration.as
+++ b/src/classes/contentsLoaders/Configuration.as
@@ -4,7 +4,14 @@ package classes.contentsLoaders {
 
     public class Configuration {
 
+        public static var SELECTION_INDEX_ATTRIBUTE:String = "@selectionIndex";
+        public static var FULL_SCREEN_MODE_ATTRIBUTE:String = "@fullScreenMode";
+
+        private var selectionIndex:int;
+        private var fullScreenMode:Boolean;
+
         private var completeEventDispatcher:EventDispatcher = new EventDispatcher();
+        private var xml:XML;
 
         public function Configuration() {
 
@@ -12,6 +19,46 @@ package classes.contentsLoaders {
 
         public function get CompleteEventDispatcher():EventDispatcher {
             return completeEventDispatcher;
+        }
+
+        /**
+         * 読み込んだ XML ファイルから情報を取り出して、このクラスのフィールドに値をセットします。
+         */
+        private function convert():void {
+            var configTag:XML = xml[ElementName][0];
+
+            if (configTag.hasOwnProperty(SELECTION_INDEX_ATTRIBUTE)) {
+                if (!isNaN(parseInt(configTag[SELECTION_INDEX_ATTRIBUTE]))) {
+                    selectionIndex = parseInt(configTag[SELECTION_INDEX_ATTRIBUTE]);
+                }
+            }
+
+            if (configTag.hasOwnProperty(FULL_SCREEN_MODE_ATTRIBUTE)) {
+                if (configTag[FULL_SCREEN_MODE_ATTRIBUTE] == "true") {
+                    fullScreenMode = true;
+                }
+            }
+        }
+
+        public function get ElementName():String {
+            return "configuration";
+        }
+
+        public function get SelectionIndex():int {
+            return selectionIndex
+        }
+
+        public function get FullScreenMode():Boolean {
+            return fullScreenMode;
+        }
+
+        /**
+         * テスト用セッター
+         * @param configXML
+         */
+        public function setConfigrationXML(configXML:XML):void {
+            xml = configXML;
+            convert();
         }
     }
 }

--- a/src/classes/contentsLoaders/Configuration.as
+++ b/src/classes/contentsLoaders/Configuration.as
@@ -1,0 +1,17 @@
+package classes.contentsLoaders {
+
+    import flash.events.EventDispatcher;
+
+    public class Configuration {
+
+        private var completeEventDispatcher:EventDispatcher = new EventDispatcher();
+
+        public function Configuration() {
+
+        }
+
+        public function get CompleteEventDispatcher():EventDispatcher {
+            return completeEventDispatcher;
+        }
+    }
+}

--- a/src/classes/contentsLoaders/Configuration.as
+++ b/src/classes/contentsLoaders/Configuration.as
@@ -18,6 +18,7 @@ package classes.contentsLoaders {
 
         private var completeEventDispatcher:EventDispatcher = new EventDispatcher();
         private var xml:XML;
+        private var file:File;
 
         public function Configuration() {
 
@@ -49,17 +50,9 @@ package classes.contentsLoaders {
         }
 
         public function load(xmlFilePath:String):void {
-            var xmlFile:File = new File(xmlFilePath);
-            if (!xmlFile.exists) {
-                var stream:FileStream = new FileStream();
-                stream.open(xmlFile, FileMode.WRITE);
-                var defaultXMLString:String = "<root><" + ElementName + " ";
-                defaultXMLString += SELECTION_INDEX_ATTRIBUTE.substr(1) + "=\"0\" ";
-                defaultXMLString += FULL_SCREEN_MODE_ATTRIBUTE.substr(1) + "=\"false\"";
-                defaultXMLString += "/></root>"
-
-                stream.writeUTFBytes(defaultXMLString);
-                stream.close();
+            file = new File(xmlFilePath);
+            if (!file.exists) {
+                exportXML(file);
             }
 
             var urlLoader:URLLoader = new URLLoader();
@@ -68,7 +61,19 @@ package classes.contentsLoaders {
                 convert();
             });
 
-            urlLoader.load(new URLRequest(xmlFile.nativePath));
+            urlLoader.load(new URLRequest(file.nativePath));
+        }
+
+        private function exportXML(xmlFile:File):void {
+            var stream:FileStream = new FileStream();
+            stream.open(xmlFile, FileMode.WRITE);
+            var defaultXMLString:String = "<root><" + ElementName + " ";
+            defaultXMLString += SELECTION_INDEX_ATTRIBUTE.substr(1) + "=\"" + selectionIndex + "\" ";
+            defaultXMLString += FULL_SCREEN_MODE_ATTRIBUTE.substr(1) + "=\"" + fullScreenMode + "\"";
+            defaultXMLString += "/></root>"
+
+            stream.writeUTFBytes(defaultXMLString);
+            stream.close();
         }
 
         public function get ElementName():String {
@@ -77,6 +82,20 @@ package classes.contentsLoaders {
 
         public function get SelectionIndex():int {
             return selectionIndex
+        }
+
+        public function set SelectionIndex(value:int):void {
+            selectionIndex = value;
+            if (file != null) {
+                exportXML(file);
+            }
+        }
+
+        public function set FullScreenMode(value:Boolean):void {
+            fullScreenMode = value;
+            if (file != null) {
+                exportXML(file);
+            }
         }
 
         public function get FullScreenMode():Boolean {

--- a/src/classes/gameScenes/SelectionScene.as
+++ b/src/classes/gameScenes/SelectionScene.as
@@ -47,6 +47,9 @@ package classes.gameScenes {
 
             config.CompleteEventDispatcher.addEventListener(Event.COMPLETE, function(e:Event):void {
                 selectionIndex = config.SelectionIndex;
+                if (config.FullScreenMode) {
+                    toggleWindowMode();
+                }
             });
 
             config.load(new File(File.applicationDirectory.nativePath).resolvePath("../commonResource/texts/configuration.xml").nativePath);
@@ -86,9 +89,7 @@ package classes.gameScenes {
             // enter でシーンを終了する。
             if (e.keyCode == Keyboard.ENTER) {
                 config.SelectionIndex = selectionIndex;
-                if (stage.displayContextInfo == StageDisplayState.FULL_SCREEN_INTERACTIVE) {
-                    config.FullScreenMode = true;
-                }
+                config.FullScreenMode = (stage.displayState == StageDisplayState.FULL_SCREEN_INTERACTIVE);
 
                 addEventListener(Event.ENTER_FRAME, exitScene);
                 removeEventListener(KeyboardEvent.KEY_DOWN, keyboardEventHandler);
@@ -101,12 +102,7 @@ package classes.gameScenes {
             }
 
             if (e.keyCode == Keyboard.F) {
-                stage.fullScreenSourceRect = Screen.mainScreen.bounds;
-                stage.displayState = StageDisplayState.FULL_SCREEN_INTERACTIVE;
-                drawingImageCapacity = Math.ceil(Screen.mainScreen.bounds.height / ThumbnailLoader.DEFAULT_THUMBNAIL_HEIGHT);
-                canvas.bitmapData = new BitmapData(ThumbnailLoader.DEFAULT_THUMBNAIL_WIDTH, ThumbnailLoader.DEFAULT_THUMBNAIL_HEIGHT * drawingImageCapacity);
-                largeThumbnailCanvas.y = (canvas.height / 4);
-                pathDisplayTextField.y = stage.stageHeight - pathDisplayTextField.height;
+                toggleWindowMode();
             }
 
             if (e.keyCode == Keyboard.DOWN || e.keyCode == Keyboard.J) {
@@ -212,6 +208,24 @@ package classes.gameScenes {
             pathDisplayTextField.height = 30;
 
             if (stage != null) {
+                pathDisplayTextField.y = stage.stageHeight - pathDisplayTextField.height;
+            }
+        }
+
+        private function toggleWindowMode():void {
+            if (!(stage.displayState == StageDisplayState.FULL_SCREEN_INTERACTIVE)) {
+                stage.fullScreenSourceRect = Screen.mainScreen.bounds;
+                stage.displayState = StageDisplayState.FULL_SCREEN_INTERACTIVE;
+                drawingImageCapacity = Math.ceil(Screen.mainScreen.bounds.height / ThumbnailLoader.DEFAULT_THUMBNAIL_HEIGHT);
+                canvas.bitmapData = new BitmapData(ThumbnailLoader.DEFAULT_THUMBNAIL_WIDTH, ThumbnailLoader.DEFAULT_THUMBNAIL_HEIGHT * drawingImageCapacity);
+                largeThumbnailCanvas.y = (canvas.height / 4);
+                pathDisplayTextField.y = stage.stageHeight - pathDisplayTextField.height;
+            } else {
+                stage.fullScreenSourceRect = Screen.mainScreen.bounds;
+                stage.displayState = StageDisplayState.NORMAL;
+                drawingImageCapacity = 5;
+                canvas.bitmapData = new BitmapData(ThumbnailLoader.DEFAULT_THUMBNAIL_WIDTH, ThumbnailLoader.DEFAULT_THUMBNAIL_HEIGHT * drawingImageCapacity);
+                largeThumbnailCanvas.y = (canvas.height / 4);
                 pathDisplayTextField.y = stage.stageHeight - pathDisplayTextField.height;
             }
         }

--- a/src/classes/gameScenes/SelectionScene.as
+++ b/src/classes/gameScenes/SelectionScene.as
@@ -19,6 +19,7 @@ package classes.gameScenes {
     import flash.text.TextField;
     import flash.text.TextFormat;
     import flash.ui.Keyboard;
+    import classes.contentsLoaders.Configuration;
 
     public class SelectionScene extends Sprite {
 
@@ -42,6 +43,13 @@ package classes.gameScenes {
                 thumbnailLoader.CompleteEventDispatcher.addEventListener(Event.COMPLETE, thumbnailLoadComplete);
                 thumbnailLoader.load();
             }
+
+            var config:Configuration = new Configuration();
+            config.CompleteEventDispatcher.addEventListener(Event.COMPLETE, function(e:Event):void {
+                selectionIndex = config.SelectionIndex;
+            });
+
+            config.load(new File(File.applicationDirectory.nativePath).resolvePath("../commonResource/texts/configuration.xml").nativePath);
 
             canvas.bitmapData = new BitmapData(ThumbnailLoader.DEFAULT_THUMBNAIL_WIDTH, ThumbnailLoader.DEFAULT_THUMBNAIL_HEIGHT * drawingImageCapacity);
             largeThumbnailCanvas.x = canvas.bitmapData.width;

--- a/src/classes/gameScenes/SelectionScene.as
+++ b/src/classes/gameScenes/SelectionScene.as
@@ -1,5 +1,6 @@
 package classes.gameScenes {
 
+    import classes.contentsLoaders.Configuration;
     import classes.contentsLoaders.ContentsLoadUtil;
     import classes.contentsLoaders.ThumbnailLoader;
     import flash.desktop.NativeApplication;
@@ -19,7 +20,6 @@ package classes.gameScenes {
     import flash.text.TextField;
     import flash.text.TextFormat;
     import flash.ui.Keyboard;
-    import classes.contentsLoaders.Configuration;
 
     public class SelectionScene extends Sprite {
 

--- a/src/classes/gameScenes/SelectionScene.as
+++ b/src/classes/gameScenes/SelectionScene.as
@@ -33,6 +33,7 @@ package classes.gameScenes {
         private var drawingImageCapacity:int = 5;
         private var frameCount:int;
         private var scrollDirection:Point = new Point(0, 0);
+        private var config:Configuration = new Configuration();
 
         public function SelectionScene() {
             var directories:Vector.<File> = ContentsLoadUtil.getFileList(new File(File.applicationDirectory.nativePath).resolvePath("../scenarios").nativePath);
@@ -44,7 +45,6 @@ package classes.gameScenes {
                 thumbnailLoader.load();
             }
 
-            var config:Configuration = new Configuration();
             config.CompleteEventDispatcher.addEventListener(Event.COMPLETE, function(e:Event):void {
                 selectionIndex = config.SelectionIndex;
             });
@@ -85,6 +85,11 @@ package classes.gameScenes {
 
             // enter でシーンを終了する。
             if (e.keyCode == Keyboard.ENTER) {
+                config.SelectionIndex = selectionIndex;
+                if (stage.displayContextInfo == StageDisplayState.FULL_SCREEN_INTERACTIVE) {
+                    config.FullScreenMode = true;
+                }
+
                 addEventListener(Event.ENTER_FRAME, exitScene);
                 removeEventListener(KeyboardEvent.KEY_DOWN, keyboardEventHandler);
                 stage.removeEventListener(MouseEvent.CLICK, resetFocus);

--- a/src/tests/contentsLoaders/TestConfiguration.as
+++ b/src/tests/contentsLoaders/TestConfiguration.as
@@ -1,0 +1,11 @@
+package tests.contentsLoaders {
+
+    public class TestConfiguration {
+        public function TestConfiguration() {
+            test();
+        }
+
+        private function test():void {
+        }
+    }
+}

--- a/src/tests/contentsLoaders/TestConfiguration.as
+++ b/src/tests/contentsLoaders/TestConfiguration.as
@@ -1,11 +1,38 @@
 package tests.contentsLoaders {
 
+    import classes.contentsLoaders.Configuration;
+    import tests.Assert;
+
     public class TestConfiguration {
         public function TestConfiguration() {
             test();
+            testInvalidXML();
         }
 
         private function test():void {
+            var config:Configuration = new Configuration();
+
+            Assert.areEqual(config.SelectionIndex, 0);
+            Assert.isFalse(config.FullScreenMode);
+
+            var xmlString:String = "<root><configuration ";
+            xmlString += "selectionIndex=\"3\" ";
+            xmlString += "fullScreenMode=\"true\" ";
+            xmlString += "/></root>"
+
+            config.setConfigrationXML(new XML(xmlString));
+
+            Assert.areEqual(config.SelectionIndex, 3);
+            Assert.isTrue(config.FullScreenMode);
+        }
+
+        private function testInvalidXML():void {
+            var invalidXMLString:String = "<root><configuration selectionIndex=\"not number\" /></root>";
+            var config:Configuration = new Configuration();
+
+            config.setConfigrationXML(new XML(invalidXMLString));
+
+            Assert.areEqual(config.SelectionIndex, 0);
         }
     }
 }


### PR DESCRIPTION
- add / アプリの初期設定を読み込み、格納するためのクラスを追加
- add / 初期設定用の XML を読み込む処理を実装
- add / 指定パスのXMLファイルを読み込む機能を実装
- add / SelectionScene に configファイルを読み込むコードを追加
- add / 選択したシーン番号、ウィンドウモードを記録、再構成する処理を実装
- add / 最後に選択していたウィンドウモードを起動時に再現するよう実装
- add / 起動時の設定のファイルを .gitignore に追加
- refactor / import をソート

ウィンドウの状態の記録、再現機能も一緒に実装

close #49
