### PR TITLE
20210731#52 feat scene reload

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -44,6 +44,8 @@ package {
         }
 
         private function loadCompleteEventHandler(event:Event):void {
+            loadingScene.removeEventListener(Event.COMPLETE, loadCompleteEventHandler);
+
             var res:Resource = LoadingScene(event.target).getResource();
 
             if (stage.displayState != StageDisplayState.FULL_SCREEN_INTERACTIVE) {
@@ -55,9 +57,21 @@ package {
 
             scenarioScene = new ScenarioScene();
             scenarioScene.setResource(res);
+            scenarioScene.addEventListener(ScenarioScene.SCENE_EXIT, reloadScene);
             addChild(scenarioScene);
             stage.focus = scenarioScene;
         }
-    }
 
+        private function reloadScene(e:Event):void {
+            removeChild(scenarioScene);
+            scenarioScene.removeEventListener(ScenarioScene.SCENE_EXIT, reloadScene);
+
+            // 現在読み込まれているシーンの情報が欲しいので、上書き前にリソースを取り出す。
+            var res:Resource = loadingScene.getResource();
+
+            loadingScene = new LoadingScene(res.sceneDirectory);
+            loadingScene.addEventListener(Event.COMPLETE, loadCompleteEventHandler);
+            loadingScene.load();
+        }
+    }
 }

--- a/src/classes/gameScenes/LoadingScene.as
+++ b/src/classes/gameScenes/LoadingScene.as
@@ -51,6 +51,7 @@ package classes.gameScenes {
                     l.writeContentsTo(resouce);
                 }
 
+                resouce.sceneDirectory = sceneDirectory
                 dispatchEvent(new Event(Event.COMPLETE));
             }
         }

--- a/src/classes/gameScenes/ScenarioScene.as
+++ b/src/classes/gameScenes/ScenarioScene.as
@@ -14,6 +14,8 @@ package classes.gameScenes {
 
     public class ScenarioScene extends Sprite {
 
+        public static var SCENE_EXIT:String = "sceneExit";
+
         private var ui:UIContainer = new UIContainer();
         private var sceneParts:Vector.<IScenarioSceneParts> = new Vector.<IScenarioSceneParts>();
         private var animators:Vector.<Animator> = new Vector.<Animator>();
@@ -106,6 +108,10 @@ package classes.gameScenes {
                     textWriter.ScenarioCounter = index;
                     playScenario();
                 }
+            }
+
+            if (event.keyCode == Keyboard.R && event.ctrlKey) {
+                dispatchEvent(new Event(SCENE_EXIT));
             }
 
             if (event.keyCode == Keyboard.Q) {

--- a/src/classes/sceneContents/Resource.as
+++ b/src/classes/sceneContents/Resource.as
@@ -5,9 +5,11 @@ package classes.sceneContents {
     import flash.geom.Rectangle;
     import flash.display.BitmapData;
     import classes.uis.UIImages;
+    import flash.filesystem.File;
 
     public class Resource {
 
+        public var sceneDirectory:File;
         public var scenarios:Vector.<Scenario> = new Vector.<Scenario>();
         private var scenariosByChapterName:Dictionary = new Dictionary();
         private var chapterHeaderIndexByChapterName:Dictionary = new Dictionary();

--- a/src/classes/sceneContents/Resource.as
+++ b/src/classes/sceneContents/Resource.as
@@ -1,11 +1,10 @@
 package classes.sceneContents {
 
-    import flash.display.Loader;
-    import flash.utils.Dictionary;
-    import flash.geom.Rectangle;
-    import flash.display.BitmapData;
     import classes.uis.UIImages;
+    import flash.display.BitmapData;
     import flash.filesystem.File;
+    import flash.geom.Rectangle;
+    import flash.utils.Dictionary;
 
     public class Resource {
 


### PR DESCRIPTION
- add / ScenarioScene に、シーン終了時のイベント送出機能を追加
- add / シナリオをロード時に、ロード対象のディレクトリをリソースに保存するよう実装
- add / シーンの読み込み機能を実装
- refactor / Resource の import を整理

close #52
