### PR TITLE
20210811#60 fix MaskSlide

### DIFF
--- a/src/classes/animes/MaskSlide.as
+++ b/src/classes/animes/MaskSlide.as
@@ -30,7 +30,7 @@ package classes.animes {
         }
 
         public function set Target(targetObject:DisplayObject):void {
-            slide.Target = targetObject.mask;
+            slide.Target = targetObject.parent.mask;
         }
 
         public function set TargetLayerIndex(index:int):void {

--- a/src/classes/sceneParts/MaskSetter.as
+++ b/src/classes/sceneParts/MaskSetter.as
@@ -21,6 +21,7 @@ package classes.sceneParts {
             }
 
             bitmapContainer.mask = maskOrder.shape;
+            UIContainer(bitmapContainer.parent).addChild(maskOrder.shape);
 
             maskOrder = null;
         }

--- a/src/tests/animes/TestMaskSlide.as
+++ b/src/tests/animes/TestMaskSlide.as
@@ -5,6 +5,7 @@ package tests.animes {
     import flash.display.Bitmap;
     import flash.display.BitmapData;
     import tests.Assert;
+    import classes.uis.BitmapContainer;
 
     public class TestMaskSlide {
         public function TestMaskSlide() {
@@ -16,10 +17,13 @@ package tests.animes {
 
             Assert.areEqual(maskSlide.TargetLayerIndex, 1);
 
-            var baseSprite:Sprite = new Sprite();
+            var bitmapContainer:BitmapContainer = new BitmapContainer(0);
+            var bmp:Bitmap = new Bitmap(new BitmapData(10, 10));
+            bitmapContainer.addChild(bmp);
             var m:Bitmap = new Bitmap(new BitmapData(10, 10, false));
-            baseSprite.mask = m;
-            maskSlide.Target = baseSprite;
+            bitmapContainer.mask = m;
+            maskSlide.Target = bmp;
+
             maskSlide.speed = 3;
             maskSlide.distance = 100;
             maskSlide.degree = 90;


### PR DESCRIPTION
- fix / MaskSlide の Target セッターの仕様を変更
- add / mask を生成した際、 UIContainer に addChild するよう変更

close #60
