### PR TITLE
20210812#62 extend AnimeElementConverter

### DIFF
--- a/src/classes/animes/LoopSlide.as
+++ b/src/classes/animes/LoopSlide.as
@@ -21,6 +21,7 @@ package classes.animes {
         private var stageRect:Rectangle;
         private var couldNotMoveCounter:int;
         private var isConstantVelocitySlide:Boolean;
+        private var directionString:String;
 
         public function LoopSlide() {
         }
@@ -40,6 +41,7 @@ package classes.animes {
                 slide.Target = target;
                 slide.degree = deg;
                 slide.speed = spd;
+                slide.direction = directionString;
                 slide.isConstantVelocity = isConstantVelocitySlide;
                 slide.distance = (distance == 0) ? measureMovableDistance() : distance;
                 if (slide.distance == 0) {
@@ -181,6 +183,10 @@ package classes.animes {
 
         public function set StageRect(value:Rectangle):void {
             stageRect = value;
+        }
+
+        public function set direction(d:String):void {
+            directionString = d;
         }
     }
 }

--- a/src/classes/animes/Slide.as
+++ b/src/classes/animes/Slide.as
@@ -129,8 +129,32 @@ package classes.animes {
                     degree = 0;
                     break;
 
+                case "rightUp":
+                    degree = 45;
+                    break;
+
                 case "right":
                     degree = 90;
+                    break;
+
+                case "rightDown":
+                    degree = 135;
+                    break;
+
+                case "down":
+                    degree = 180;
+                    break;
+
+                case "leftDown":
+                    degree = 225;
+                    break;
+
+                case "left":
+                    degree = 270;
+                    break;
+
+                case "leftUP":
+                    degree = 315;
                     break;
 
                 default:

--- a/src/classes/animes/Slide.as
+++ b/src/classes/animes/Slide.as
@@ -122,5 +122,20 @@ package classes.animes {
         public function get TargetLayerIndex():int {
             return targetLayerIndex;
         }
+
+        public function set direction(d:String):void {
+            switch (d) {
+                case "up":
+                    degree = 0;
+                    break;
+
+                case "right":
+                    degree = 90;
+                    break;
+
+                default:
+                    break;
+            }
+        }
     }
 }

--- a/src/classes/contentsLoaders/xmlElements/AnimeElementConverter.as
+++ b/src/classes/contentsLoaders/xmlElements/AnimeElementConverter.as
@@ -29,13 +29,16 @@ package classes.contentsLoaders.xmlElements {
                         continue;
                     }
 
+                    var propertyName:String = attribute.name();
+
                     if (!isNaN(parseFloat(attribute))) {
-                        var propertyName:String = attribute.name();
                         anime[propertyName] = parseFloat(attribute);
                     }
 
                     if (attribute.name() == TARGET_ATTRIBUTE.substr(1)) {
                         anime.TargetLayerIndex = TargetAttributeConverter.getLayerIndexFromTargetName(String(attribute));
+                    } else {
+                        anime[propertyName] = String(attribute);
                     }
 
                 }

--- a/src/classes/contentsLoaders/xmlElements/AnimeElementConverter.as
+++ b/src/classes/contentsLoaders/xmlElements/AnimeElementConverter.as
@@ -38,8 +38,9 @@ package classes.contentsLoaders.xmlElements {
                         anime.TargetLayerIndex = TargetAttributeConverter.getLayerIndexFromTargetName(String(attribute));
                     }
 
-                    scenario.Animations.push(anime);
                 }
+
+                scenario.Animations.push(anime);
             }
         }
 

--- a/src/tests/contentsLoaders/xmlElements/TestAnimeElementConverter.as
+++ b/src/tests/contentsLoaders/xmlElements/TestAnimeElementConverter.as
@@ -5,6 +5,11 @@ package tests.contentsLoaders.xmlElements {
     import tests.Assert;
     import classes.animes.Shake;
     import classes.animes.AlphaChanger;
+    import classes.animes.LoopSlide;
+    import flash.display.Sprite;
+    import flash.geom.Rectangle;
+    import flash.display.Bitmap;
+    import flash.display.BitmapData;
 
     public class TestAnimeElementConverter {
         public function TestAnimeElementConverter() {
@@ -16,6 +21,7 @@ package tests.contentsLoaders.xmlElements {
             var scenario:Scenario = new Scenario();
             var xmlText:String = "<scenario>  <anime name=\"shake\" strength=\"25\" /> ";
             xmlText += "<anime name=\"alphaChanger\" amount=\"0.5\" target=\"background\" /> ";
+            xmlText += "<anime name=\"slide\" speed=\"10\" direction=\"right\" /> ";
             xmlText += "</scenario>";
             var xml:XML = new XML(xmlText);
 
@@ -25,6 +31,19 @@ package tests.contentsLoaders.xmlElements {
 
             Assert.isTrue(scenario.Animations[1] is AlphaChanger);
             Assert.areEqual(scenario.Animations[1].TargetLayerIndex, 0);
+
+            var bmp:Bitmap = new Bitmap(new BitmapData(200, 200));
+            scenario.Animations[2].Target = bmp;
+            LoopSlide(scenario.Animations[2]).StageRect = new Rectangle(0, 0, 100, 100);
+            Assert.isTrue(scenario.Animations[2] is LoopSlide);
+
+            scenario.Animations[2].execute();
+            scenario.Animations[2].execute();
+            scenario.Animations[2].execute();
+
+            // xml から文字列で "right" を入力しているので、bmp は横方向にスライドする。
+            // つまり、|x| は 0 より大きく、 y は 0 のままの状態。 
+            Assert.isTrue(Math.abs(bmp.x) > 0 && bmp.y == 0);
         }
     }
 }


### PR DESCRIPTION
- add / スライドアニメーションに文字列から方角を設定できるプロパティを追加
- fix / コードを配置する階層を間違えていたので修正
- add / xml の anime 要素から文字列型のプロパティも読み込めるよう実装
- add / Slide の direction プロパティに追記

close #62
